### PR TITLE
Dependency updates.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # webkms-switch ChangeLog
 
+## x.x.x - TBD
+
+### Changed
+- Use http-signature-zcap-verify@4.
+- Use jsonld-signatures@7.
+
 ## 2.0.0 - 2020-04-02
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -29,13 +29,13 @@
     "lib": "./lib"
   },
   "devDependencies": {
-    "eslint": "^6.8.0",
-    "eslint-config-digitalbazaar": "^2.0.0"
+    "eslint": "^7.19.0",
+    "eslint-config-digitalbazaar": "^2.6.1"
   },
   "dependencies": {
     "ajv": "^6.0.0",
     "bs58": "^4.0.1",
-    "http-signature-zcap-verify": "^3.0.0",
+    "http-signature-zcap-verify": "github:digitalbazaar/http-signature-zcap-verify#add-now-to-parse-request",
     "jsonld-signatures": "^5.0.0",
     "ocapld": "^2.0.0"
   }

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "dependencies": {
     "ajv": "^6.0.0",
     "bs58": "^4.0.1",
-    "http-signature-zcap-verify": "github:digitalbazaar/http-signature-zcap-verify#add-now-to-parse-request",
+    "http-signature-zcap-verify": "^4.0.0",
     "jsonld-signatures": "^5.0.0",
     "ocapld": "^2.0.0"
   }

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "ajv": "^6.0.0",
     "bs58": "^4.0.1",
     "http-signature-zcap-verify": "^4.0.0",
-    "jsonld-signatures": "^5.0.0",
+    "jsonld-signatures": "^7.0.0",
     "ocapld": "^2.0.0"
   }
 }


### PR DESCRIPTION
I believe this is going to be a breaking release due to changes in the http-signature-zcap headers included in http-signature-zcap-verify@4.

### Changed
- Use http-signature-zcap-verify@4.
- Use jsonld-signatures@7.